### PR TITLE
Update FileService.php

### DIFF
--- a/src/Service/FileService.php
+++ b/src/Service/FileService.php
@@ -162,6 +162,7 @@ class FileService
         $file->setMimeType(($mimeType ?? 'application/pdf'));
         $extension = match ($file->getMimeType()) {
             'pdf', 'application/pdf' => 'pdf',
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => 'docx',
             default => '',
         };
 


### PR DESCRIPTION
Issue Identified:

`.docx` MIME Type Not Handled: The MIME type for `.docx` files (application/vnd.openxmlformats-officedocument.wordprocessingml.document) isn't accounted for in the match statement. As a result, the default case is triggered, setting the extension to an empty string (''), even though the filename contains .docx.

While your filename includes .docx, the method doesn't extract the extension from the filename. Instead, it relies on the MIME type to set the extension. This approach can lead to inconsistencies, especially if the MIME type isn't mapped correctly, as in your case.

Recommendations to Handle .docx MIME Type Properly To ensure that your method correctly handles .docx files, you should update the logic to recognize the .docx MIME type and assign the appropriate extension. Here are several ways to achieve this: